### PR TITLE
Rename async/await keywords

### DIFF
--- a/mandrill.py
+++ b/mandrill.py
@@ -1292,7 +1292,7 @@ class Messages(object):
     def __init__(self, master):
         self.master = master
 
-    def send(self, message, async=False, ip_pool=None, send_at=None):
+    def send(self, message, send_async=False, ip_pool=None, send_at=None):
         """Send a new transactional message through Mandrill
 
         Args:
@@ -1369,7 +1369,7 @@ class Messages(object):
                        message.images[].content (string): the content of the image as a base64-encoded string
 
 
-           async (boolean): enable a background sending mode that is optimized for bulk sending. In async mode, messages/send will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
+           send_async (boolean): enable a background sending mode that is optimized for bulk sending. In async mode, messages/send will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
            ip_pool (string): the name of the dedicated ip pool that should be used to send the message. If you do not have any dedicated IPs, this parameter has no effect. If you specify a pool that does not exist, your default pool will be used instead.
            send_at (string): when this message should be sent as a UTC timestamp in YYYY-MM-DD HH:MM:SS format. If you specify a time in the past, the message will be sent immediately. An additional fee applies for scheduled email, and this feature is only available to accounts with a positive balance.
 
@@ -1388,10 +1388,10 @@ class Messages(object):
            UnknownSubaccountError: The provided subaccount id does not exist.
            Error: A general Mandrill error has occurred
         """
-        _params = {'message': message, 'async': async, 'ip_pool': ip_pool, 'send_at': send_at}
+        _params = {'message': message, 'async': send_async, 'ip_pool': ip_pool, 'send_at': send_at}
         return self.master.call('messages/send', _params)
 
-    def send_template(self, template_name, template_content, message, async=False, ip_pool=None, send_at=None):
+    def send_template(self, template_name, template_content, message, send_async=False, ip_pool=None, send_at=None):
         """Send a new transactional message through Mandrill using a template
 
         Args:
@@ -1474,7 +1474,7 @@ class Messages(object):
                        message.images[].content (string): the content of the image as a base64-encoded string
 
 
-           async (boolean): enable a background sending mode that is optimized for bulk sending. In async mode, messages/send will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
+           send_async (boolean): enable a background sending mode that is optimized for bulk sending. In async mode, messages/send will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
            ip_pool (string): the name of the dedicated ip pool that should be used to send the message. If you do not have any dedicated IPs, this parameter has no effect. If you specify a pool that does not exist, your default pool will be used instead.
            send_at (string): when this message should be sent as a UTC timestamp in YYYY-MM-DD HH:MM:SS format. If you specify a time in the past, the message will be sent immediately. An additional fee applies for scheduled email, and this feature is only available to accounts with a positive balance.
 
@@ -1494,7 +1494,7 @@ class Messages(object):
            UnknownSubaccountError: The provided subaccount id does not exist.
            Error: A general Mandrill error has occurred
         """
-        _params = {'template_name': template_name, 'template_content': template_content, 'message': message, 'async': async, 'ip_pool': ip_pool, 'send_at': send_at}
+        _params = {'template_name': template_name, 'template_content': template_content, 'message': message, 'async': send_async, 'ip_pool': ip_pool, 'send_at': send_at}
         return self.master.call('messages/send-template', _params)
 
     def search(self, query='*', date_from=None, date_to=None, tags=None, senders=None, api_keys=None, limit=100):
@@ -1729,7 +1729,7 @@ class Messages(object):
         _params = {'raw_message': raw_message}
         return self.master.call('messages/parse', _params)
 
-    def send_raw(self, raw_message, from_email=None, from_name=None, to=None, async=False, ip_pool=None, send_at=None, return_path_domain=None):
+    def send_raw(self, raw_message, from_email=None, from_name=None, to=None, send_async=False, ip_pool=None, send_at=None, return_path_domain=None):
         """Take a raw MIME document for a message, and send it exactly as if it were sent through Mandrill's SMTP servers
 
         Args:
@@ -1738,7 +1738,7 @@ class Messages(object):
            from_name (string|null): optionally define the sender alias
            to (array|null): optionally define the recipients to receive the message - otherwise we'll use the To, Cc, and Bcc headers provided in the document::
                to[] (string): the email address of the recipient
-           async (boolean): enable a background sending mode that is optimized for bulk sending. In async mode, messages/sendRaw will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
+           send_async (boolean): enable a background sending mode that is optimized for bulk sending. In async mode, messages/sendRaw will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
            ip_pool (string): the name of the dedicated ip pool that should be used to send the message. If you do not have any dedicated IPs, this parameter has no effect. If you specify a pool that does not exist, your default pool will be used instead.
            send_at (string): when this message should be sent as a UTC timestamp in YYYY-MM-DD HH:MM:SS format. If you specify a time in the past, the message will be sent immediately.
            return_path_domain (string): a custom domain to use for the messages's return-path
@@ -1759,7 +1759,7 @@ class Messages(object):
            UnknownSubaccountError: The provided subaccount id does not exist.
            Error: A general Mandrill error has occurred
         """
-        _params = {'raw_message': raw_message, 'from_email': from_email, 'from_name': from_name, 'to': to, 'async': async, 'ip_pool': ip_pool, 'send_at': send_at, 'return_path_domain': return_path_domain}
+        _params = {'raw_message': raw_message, 'from_email': from_email, 'from_name': from_name, 'to': to, 'async': send_async, 'ip_pool': ip_pool, 'send_at': send_at, 'return_path_domain': return_path_domain}
         return self.master.call('messages/send-raw', _params)
 
     def list_scheduled(self, to=None):


### PR DESCRIPTION
Now that python3.7 has been released, these are now reserved keywords
for the language itself and can't be used as kwargs anymore.